### PR TITLE
Plan macro copilot chatbot roadmap

### DIFF
--- a/DEVELOPMENT_IDEAS.md
+++ b/DEVELOPMENT_IDEAS.md
@@ -1,0 +1,56 @@
+# Ray Dalio Macro Copilot – From Transcripts to Actionable Software
+
+This document translates the transcripts into a concrete software concept: a “Ray Dalio Macro Copilot” that behaves like a chatbot, connects to real-time data, and helps users make decisions grounded in Dalio’s principles. The plan below breaks the problem into shippable components that can be built iteratively.
+
+## 1. Product Vision and User Promises
+- **Guided macro dialogue.** Users can ask, “Where are the U.S. and China in the big cycle?” or “How do today’s inflation prints affect my portfolio?” and receive responses that cite Dalio’s frameworks plus fresh data. Conversations include follow-up prompts that nudge users toward objective reasoning (triangulation, second-order effects).【F:2023-06-14_Thomas Friedman and Ray Dalio Discuss the Changing World Order.txt†L124-L179】【F:2018-05-21_Principles For Success by Ray Dalio.txt†L980-L1035】
+- **Cycle-aware alerts.** The copilot flags when indicators cross thresholds that correspond to Dalio’s risk regimes—e.g., debt-service-to-income > 20% triggers deleveraging watch, falling education and innovation scores warn of empire decline.【F:2025-06-25_How Countries Go Broke: The Big Cycle, Chapter 1.txt†L200-L316】【F:2023-06-14_Thomas Friedman and Ray Dalio Discuss the Changing World Order.txt†L124-L179】
+- **Decision journaling.** Each recommendation includes a structured template (thesis, data, principle, confidence). Users can log outcomes to compound learning, reflecting Dalio’s emphasis on feedback loops.【F:2018-05-21_Principles For Success by Ray Dalio.txt†L980-L1035】
+
+## 2. System Architecture Overview
+| Layer | Purpose | Key Assets |
+| --- | --- | --- |
+| **Knowledge Base** | Curated transcript snippets, extracted principles, formula sheets (e.g., `Price = (Money + Credit) / Quantity`, debt-service ratios). | Manual curation + embedding store built from provided documents.【F:2013-09-22_How The Economic Machine Works by Ray Dalio.txt†L15-L110】 |
+| **Data Ingestion** | Scheduled pull of macro data (FRED, IMF), market feeds, geopolitical news APIs. Map each data point to Dalio’s five forces and eight power metrics. | Mapping schema derived from transcripts about the five forces and empire metrics.【F:2024-04-11_An Update on Ray Dalio's Views of The Five Big Forces Shaping 2024.txt†L110-L160】【F:2023-06-14_Thomas Friedman and Ray Dalio Discuss the Changing World Order.txt†L124-L179】 |
+| **Reasoning Engine** | Retrieval-augmented generation + rule engine. Retrieval grounds responses in transcripts; rule engine evaluates formulas/thresholds before language generation. | Formula and trigger catalog (debt-to-income, reserve-currency share, education z-scores).【F:2025-06-25_How Countries Go Broke: The Big Cycle, Chapter 1.txt†L200-L316】 |
+| **Experience Layer** | Chat UI, dashboard overlays (power-shift gauge, five forces heat map), alert configuration, decision journal. | Components described in Sections 3–4. |
+
+## 3. Core Analytical Modules to Implement
+1. **Power-Shift Diagnostic (U.S. vs. China).**
+   - Composite power scoreboard combining the eight metrics Dalio tracks (normalize to 0–100, show trailing trends).【F:2023-06-14_Thomas Friedman and Ray Dalio Discuss the Changing World Order.txt†L124-L150】
+   - Cycle-stage classifier that labels each country’s position on the long-term empire arc using thresholds for debt, inequality, and conflict signals.【F:2023-06-14_Thomas Friedman and Ray Dalio Discuss the Changing World Order.txt†L144-L179】
+   - Scenario engine for China’s legalist vs. reform paths, adjusting GDP growth, innovation adoption, and capital flows to project convergence timelines.【F:2024-04-11_An Update on Ray Dalio's Views of The Five Big Forces Shaping 2024.txt†L627-L739】
+2. **Five Forces Monitor.**
+   - Data tagging service that classifies incoming events into debt/monetary, internal order, external order, nature, or human inventiveness to surface cross-force feedback loops.【F:2024-04-11_An Update on Ray Dalio's Views of The Five Big Forces Shaping 2024.txt†L110-L159】
+   - Debt-cycle state machine tracking expansion → bubble → peak → deleveraging using debt-growth vs. income, asset inflation, and monetary policy stance.【F:2025-06-25_How Countries Go Broke: The Big Cycle, Chapter 1.txt†L200-L316】
+   - Polarization risk gauge that watches wealth gaps, value divides, and political gridlock as leading indicators of internal order stress.【F:2024-04-11_An Update on Ray Dalio's Views of The Five Big Forces Shaping 2024.txt†L493-L620】
+3. **Objective News Summarizer.**
+   - Believability scoring of sources (expertise, track record) to weight headlines, echoing Dalio’s idea-meritocracy approach.【F:2018-05-21_Principles For Success by Ray Dalio.txt†L980-L1035】
+   - Principle-aligned summarization that maps each article to relevant principles, data series, and risk regimes before generating a chat response.【F:2024-04-11_An Update on Ray Dalio's Views of The Five Big Forces Shaping 2024.txt†L110-L159】
+   - Decision journal hooks allowing users to log hypotheses and later compare outcomes, reinforcing reflective practice.【F:2018-05-21_Principles For Success by Ray Dalio.txt†L980-L1035】
+
+## 4. Build Roadmap
+1. **Phase 0 – Corpus + Principle Extraction (1–2 sprints).**
+   - Clean and segment transcripts into Q&A chunks, tag principles, formulas, and decision rules.
+   - Generate embeddings and store metadata (force, cycle stage, metric type) for retrieval.
+2. **Phase 1 – Insightful Retrieval Chat (2 sprints).**
+   - Stand up RAG service that answers questions with transcript citations and pre-computed metric lookups (e.g., debt-service ratios, CPI trends).
+   - Implement minimal UI (web or Slack) with prompt templates enforcing Dalio-style diagnostics (what is the force, what are second-order impacts?).
+3. **Phase 2 – Data Fusion & Scoring (3–4 sprints).**
+   - Integrate macro and market data APIs, compute standardized scores for the eight power metrics and five forces.
+   - Add rule engine for cycle thresholds; surface alerts and scenario charts in the chat via cards or linked dashboards.
+4. **Phase 3 – Proactive Copilot (4+ sprints).**
+   - Incorporate news ingestion with believability weighting, automatically summarize daily developments in Dalio terms.
+   - Expand decision journal, recommendations, and backtesting hooks to connect suggested actions (e.g., hedge inflation risk) with historical outcomes.
+
+## 5. Example User Journeys
+- **Investor asking about U.S. vs. China:** Copilot retrieves long-term debt cycle commentary, overlays current debt-service ratios, and suggests scenario comparisons with data tables and principle references.【F:2023-06-14_Thomas Friedman and Ray Dalio Discuss the Changing World Order.txt†L124-L179】
+- **Policy analyst monitoring internal order:** Daily briefing highlights shifts in inequality data, labor strikes, and polarization metrics, tied to Dalio’s internal-order warnings.【F:2024-04-11_An Update on Ray Dalio's Views of The Five Big Forces Shaping 2024.txt†L493-L620】
+- **General user consuming headlines:** News ingestion module grades sources, maps stories to forces, and recommends journal entries (“Record your thesis on how this affects external order risk”).【F:2018-05-21_Principles For Success by Ray Dalio.txt†L980-L1035】
+
+## 6. Implementation Assets Checklist
+- Transcript-derived formula library (transaction identity, debt burdens, reserve-currency indicators).【F:2013-09-22_How The Economic Machine Works by Ray Dalio.txt†L15-L110】
+- Metric definitions and data sources for each power metric and force (e.g., OECD education scores, patent counts, military expenditure, FX reserves).【F:2023-06-14_Thomas Friedman and Ray Dalio Discuss the Changing World Order.txt†L124-L179】【F:2024-04-11_An Update on Ray Dalio's Views of The Five Big Forces Shaping 2024.txt†L110-L159】
+- Principle tagging schema for believability, triangulation, and thoughtful disagreement workflows.【F:2018-05-21_Principles For Success by Ray Dalio.txt†L980-L1035】
+
+By following this plan, the complex ideas in the transcripts become an actionable roadmap for a chatbot-style product that continuously grounds its guidance in Dalio’s principles while staying synced with real-world events.


### PR DESCRIPTION
## Summary
- reframe development document around a Ray Dalio macro copilot chatbot concept
- outline architecture layers, analytical modules, and implementation phases for the copilot
- retain transcript citations to ground formulas, data mappings, and user journeys

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690260895f108325860dbc90eb0a0670